### PR TITLE
Fix for typst 0.13.0

### DIFF
--- a/blinky.typ
+++ b/blinky.typ
@@ -5,7 +5,7 @@
 
 #let link-bib-urls(bibsrc, content) = {
   let serialized = p.get_bib_map(bytes(bibsrc))
-  let bib_map = cbor.decode(serialized)
+  let bib_map = cbor(serialized)
 
   show bib_re: it => {
     let (key,) = it.text.match(bib_re).captures

--- a/typst-template.toml
+++ b/typst-template.toml
@@ -1,7 +1,8 @@
 
 [package]
 name = "blinky"
-version = "VERSION"
+version = "0.1.0"
+compiler = "0.13.0"
 entrypoint = "lib.typ"
 authors = ["Alexander Koller <akoller@gmail.com>"]
 license = "MIT"


### PR DESCRIPTION
Hello, since typst [0.13.0](https://typst.app/docs/changelog/0.13.0/):
> [image](https://typst.app/docs/reference/visualize/image/), [cbor](https://typst.app/docs/reference/data-loading/cbor/), [csv](https://typst.app/docs/reference/data-loading/csv/), [json](https://typst.app/docs/reference/data-loading/json/), [toml](https://typst.app/docs/reference/data-loading/toml/), [xml](https://typst.app/docs/reference/data-loading/xml/), and [yaml](https://typst.app/docs/reference/data-loading/yaml/) now support a path string or bytes and their .decode variants are deprecated

I've changed the `lib.typ` to reflect this change and updated the `typst.toml` to reflect the new minimum compiler version.